### PR TITLE
Check for tag aliases when loading tag count

### DIFF
--- a/src/popup/pages/PopupMain.vue
+++ b/src/popup/pages/PopupMain.vue
@@ -313,12 +313,11 @@ async function loadTagCounts() {
     // Not the best code, but it works I guess?
     if (resp) {
       for (let post of pop.posts)
-        for (let tag of resp.results)
-          for (let postTag of post.tags)
-            if (tag.names.includes(postTag.name)) {
-              postTag.usages = tag.usages;
-              break;
-            }
+        for (let tag of resp.results) {
+          post.tags
+            .find(postTag => tag.names.includes(postTag.name))
+            .usages = tag.usages;
+        }
     }
   }
 }

--- a/src/popup/pages/PopupMain.vue
+++ b/src/popup/pages/PopupMain.vue
@@ -315,7 +315,7 @@ async function loadTagCounts() {
       for (let post of pop.posts)
         for (let tag of resp.results)
           for (let postTag of post.tags)
-            if (postTag.name == tag.names[0]) {
+            if (tag.names.includes(postTag.name)) {
               postTag.usages = tag.usages;
               break;
             }


### PR DESCRIPTION
I am not sure whether this is intentional or not, but when the tag being imported is an alias of the tag on the destination booru, the tag count doesn't show up.

Example: if I'm trying to import a `vtuber` tag, which is an alias for `virtual_youtuber` on my booru but isn't the first name, then the tag count isn't shown.

In my first commit I addressed the issue, in the second I tried to refactor the code but I am not sure whether this is actually "better code", as I don't have much experience with code style in js.