### PR TITLE
Fix hyperlinks by opening a new tab in background using browser.tabs

### DIFF
--- a/src/popup/pages/PopupMain.vue
+++ b/src/popup/pages/PopupMain.vue
@@ -384,6 +384,10 @@ function getUpdatedTagsText(count: number) {
   return `Updated ${count} tag${count > 1 ? "s" : ""}`;
 }
 
+async function openNewTab(url: string) {
+  browser.tabs.create({url, active:false});
+}
+
 function onResolutionLoaded(res: any) {
   // This no longer checks for `!pop.selectedPost.resolution` because the resolution can change if the contentUrl is updated.
   if (pop.selectedPost) {
@@ -416,9 +420,10 @@ useDark();
       </div>
 
       <div v-if="instanceSpecificData?.reverseSearchResult?.exactPostId" class="bg-danger has-merge-button">
-        <a :href="getActiveSitePostUrl(instanceSpecificData.reverseSearchResult?.exactPostId)">
-          Post already uploaded ({{ instanceSpecificData.reverseSearchResult.exactPostId }})
-        </a>
+        <a href="#"
+          @click.prevent="openNewTab(getActiveSitePostUrl(instanceSpecificData.reverseSearchResult?.exactPostId))"
+          >Post already uploaded ({{ instanceSpecificData.reverseSearchResult.exactPostId }}) </a
+        >
 
         <!-- TODO: Maybe a 5px gap here? -->
 
@@ -460,8 +465,9 @@ useDark();
         "
         class="bg-success"
       >
-        <a :href="getActiveSitePostUrl(instanceSpecificData.uploadState.instancePostId)"
-          >Uploaded post {{ instanceSpecificData.uploadState.instancePostId }}</a
+        <a href="#" 
+          @click="openNewTab(getActiveSitePostUrl(instanceSpecificData.uploadState.instancePostId))"
+          >Uploaded post {{ instanceSpecificData.uploadState.instancePostId }} </a
         >
       </div>
 
@@ -515,7 +521,8 @@ useDark();
         :key="similarPost.id"
         class="has-merge-button"
       >
-        <a :href="getActiveSitePostUrl(similarPost.id)"
+        <a href="#"
+          @click.prevent="openNewTab(getActiveSitePostUrl(similarPost.id))"
           >Post {{ similarPost.id }} looks {{ similarPost.percentage }}% similar</a
         >
 


### PR DESCRIPTION
This should fix and close #3 

I am not a fan of this html syntax and I saw it was repeatedly changed in past commits, might be a good idea to edit prettier config? Though I have no idea how it works and I probably should actually look into it on my own.

[This](https://stackoverflow.com/questions/52900565/vue-click-doesnt-work-on-an-anchor-tag-with-href-present) suggested keeping the actual href but it was getting cluttered and the whole extension wouldn't work with javascript disabled so I think it's safe to keep a `#` placeholder and rely on the `@click` event.

I set the new tabs to open without focus as changing tabs closes the popup and loses eventual progress, might be cool to persist the state until the page is closed or something like that.