### PR TITLE
Add configurable list of tags to ignore

### DIFF
--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -8,7 +8,7 @@ import TabView from "primevue/tabview";
 import TabPanel from "primevue/tabpanel";
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
-import { SzuruSiteConfig, TagCategoryColor, getDefaultTagCategories } from "~/models";
+import { TagDetails, SzuruSiteConfig, TagCategoryColor, getDefaultTagCategories } from "~/models";
 import SzurubooruApi from "~/api";
 
 type StatusType = "success" | "error" | "quiet";
@@ -100,6 +100,14 @@ async function importTagCategoriesFromInstance() {
       cfg.value.tagCategories.push(new TagCategoryColor(cat.name, cat.color));
     }
   }
+}
+
+function addTagIgnore() {
+  cfg.value.tagIgnores.push(new TagDetails([""]))
+}
+
+function resetTagIgnores() {
+  cfg.value.tagIgnores.splice(0);
 }
 
 // For debugging
@@ -289,7 +297,26 @@ wnd.szc_set_config_version = (v = 0) => (cfg.value.version = v);
 
           <!-- TODO: Tag category colors -->
 
-          <!-- TODO: Tag ignore list -->
+          <div class="grid">
+            <DataTable :value="cfg.tagIgnores" table-class="col-12" style="width: 100%">
+              <Column field="names" :header="'Names'">
+                <template #body="{ data, field }">
+                  <input type="text" :name="field" v-model="data[field][0]" />
+                </template>
+              </Column>
+
+              <Column field="remove">
+                <template #body="{ index }">
+                  <a class="color-primary cursor-pointer" @click="() => cfg.tagIgnores.splice(index, 1)">Remove</a>
+                </template>
+              </Column>
+            </DataTable>
+
+            <div class="col-12 flex flex-wrap grid grid-nogutter gap-1">
+              <button class="primary" @click="addTagIgnore">Add tag</button>
+              <button class="bg-danger sm:ml-auto" @click="resetTagIgnores">Clear</button>
+            </div>
+          </div>
 
           <!-- TODO: Category ignore list -->
         </TabPanel>

--- a/src/popup/pages/PopupMain.vue
+++ b/src/popup/pages/PopupMain.vue
@@ -121,6 +121,12 @@ async function grabPost() {
         vm.instanceSpecificData[site.id] = {};
       }
 
+      // Remove ignored tags
+      // The complexity for this is quite bad but all the other ways I tried were even worse
+      vm.tags = vm.tags.filter(tag => cfg.value.tagIgnores.every(
+        ignoredTag => tag.name != ignoredTag.names[0] // no getters after deserializing
+      ));
+
       pop.posts.push(vm);
     }
   }

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import deepMerge from "deepmerge";
 import {
+  type TagDetails,
   getDefaultTagCategories,
   type ScrapedPostDetails,
   type SetPostUploadInfoData,
@@ -38,6 +39,7 @@ export const cfg = useStorageLocal(
       showInstancePicker: true,
     },
     tagCategories: [] as Array<TagCategoryColor>,
+    tagIgnores: [] as Array<TagDetails>,
   },
   {
     mergeDefaults(storageValue, defaults) {


### PR DESCRIPTION
Should close #48 

This should be pretty easy to implement, I'm drafting this mainly because of style issues.
As of now I'm recycling the `TagDetail` model but I'm only using the first name, it'd be nice to allow for aliases when ignoring but it could get a bit cluttered and I'm pretty sure it wouldn't be possible with simple bindings; on the other hand, it might make more sense to create a separate model (or use simple strings) for the names to be saved in the config.

Also I kinda suck at front-end so if this ends up going through I'm gonna ask you to smooth the rough edges 🙏