### PR TITLE
Add Always upload as content option

### DIFF
--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -139,6 +139,17 @@ wnd.szc_set_config_version = (v = 0) => (cfg.value.version = v);
               </p>
             </div>
 
+            <div class="col-12 md:col-6">
+              <label>
+                <input type="checkbox" v-model="cfg.alwaysUploadAsContent" />
+                Always upload as content
+              </label>
+              <p class="hint">
+                This will always upload the image content directly, instead of
+                as an URL
+              </p>
+            </div>
+
             <span class="col-12 status-quiet">{{ versionInfo }}</span>
           </div>
         </TabPanel>

--- a/src/popup/pages/PopupMain.vue
+++ b/src/popup/pages/PopupMain.vue
@@ -162,8 +162,12 @@ async function upload() {
   try {
     const post: ScrapedPostDetails = cloneDeep(pop.selectedPost)!;
 
-    // uploadMode "content" requires a content token to work. So ensure it is set.
-    if (post.uploadMode == "content") {
+    // uploadMode "content" requires a content token to work. So ensure it is
+    // set. Ignore fallback "Upload as URL" mode as well
+    if (
+      (cfg.value.alwaysUploadAsContent || post.uploadMode === "content")
+        && post.name !== "[fallback] Upload as URL"
+    ) {
       await ensurePostHasContentToken(post);
     }
 
@@ -257,7 +261,10 @@ async function ensurePostHasContentToken(post: ScrapedPostDetails) {
   }
 
   try {
-    let tmpRes = await selectedInstance.uploadTempFile(post.contentUrl, post.uploadMode);
+    const uploadMode =
+      cfg.value.alwaysUploadAsContent && post.name !== "[fallback] Upload as URL" ?
+        'content' : post.uploadMode;
+    let tmpRes = await selectedInstance.uploadTempFile(post.contentUrl, uploadMode);
     // Save contentToken in PostViewModel so that we can reuse it when creating/uploading the post.
     instanceSpecificData.contentToken = tmpRes.token;
   } catch (ex) {
@@ -403,7 +410,7 @@ useDark();
 <template>
   <div class="popup-messages">
     <div class="messages">
-      <!-- 
+      <!--
         Error messages
       -->
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -14,6 +14,7 @@ export const cfg = useStorageLocal(
   {
     version: 0,
     addPageUrlToSource: true,
+    alwaysUploadAsContent: false,
     autoSearchSimilar: false,
     loadTagCounts: true,
     fetchPostInfo: true,


### PR DESCRIPTION
This PR adds an always upload as content option and attempts to ignore the fallback's "Upload as URL" option.

Preview:
![2024-11-04_23-11-1730780060](https://github.com/user-attachments/assets/a02a5d2e-a4b0-49c0-a44a-1925f3261984)

Closes #62