### PR TITLE
Fix undefined tag usages access in PopupMain.vue

### DIFF
--- a/src/popup/pages/PopupMain.vue
+++ b/src/popup/pages/PopupMain.vue
@@ -314,9 +314,8 @@ async function loadTagCounts() {
     if (resp) {
       for (let post of pop.posts)
         for (let tag of resp.results) {
-          // @ts-expect-error .find() can't return undefined because the resp.results list can only contain
-          // the tags which we requested. And we only request the tags which are already set on the post.
-          post.tags.find((postTag) => tag.names.includes(postTag.name)).usages = tag.usages;
+          const postTag = post.tags.find((postTag) => tag.names.includes(postTag.name));
+          if(postTag) postTag.usages = tag.usages;
         }
     }
   }


### PR DESCRIPTION
Fixes bug introduced with my last PR (#55) where an error is thrown because we didn't check if the result of `find()` was undefined.
This was assumed not to be a problem as we only retrieved the tags that were already present in the post we meant to upload, but we failed to consider that the tags were being retrieved for all posts (including those with no tags due to fallback), which actually lead to *always* failing as soon as it gets to the first fallback post.

This does not really impact anything at all at the moment, but it was in the way of another improvement I'm working on and it was quite an easy fix so I'm creating this PR to address it.